### PR TITLE
Use the correct name of the orb in the orb registry links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Artifactory Orb ![CircleCI status](https://circleci.com/gh/jfrog/artifactory-orb.svg "CircleCI status") [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/jfrog/artifactory)](https://circleci.com/orbs/registry/orb/jfrog/artifactory) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/jfrog/artifactory-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/orbs)
+# Artifactory Orb ![CircleCI status](https://circleci.com/gh/jfrog/artifactory-orb.svg "CircleCI status") [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/jfrog/artifactory)](https://circleci.com/orbs/registry/orb/jfrog/artifactory-orb) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/jfrog/artifactory-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/orbs)
 
 JFrog Artifactory orb created in partnership with CircleCI.
 
@@ -8,10 +8,10 @@ This orb supports the major features of the [JFrog CLI](https://jfrog.com/conflu
 To limit the permutations of variables, advanced users may pass a [File Spec](https://jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory#CLIforJFrogArtifactory-UsingFileSpecs).
 
 ### Examples
-For usage examples, see the [src/examples](https://github.com/jfrog/artifactory-orb/tree/master/src/examples) directory or the [listing in the orb registry](https://circleci.com/orbs/registry/orb/jfrog/artifactory).
+For usage examples, see the [src/examples](https://github.com/jfrog/artifactory-orb/tree/master/src/examples) directory or the [listing in the orb registry](https://circleci.com/orbs/registry/orb/jfrog/artifactory-orb).
 
 ### Parameters/Configuration
-See [orb registry listing](https://circleci.com/orbs/registry/orb/jfrog/artifactory) for complete parameters information.
+See [orb registry listing](https://circleci.com/orbs/registry/orb/jfrog/artifactory-orb) for complete parameters information.
 
 ## Contributing
 [Issues](https://github.com/jfrog/artifactory-orb/issues) and [pull requests](https://github.com/jfrog/artifactory-orb/pulls) welcome!


### PR DESCRIPTION
This PR fixes issue #2 by correcting the orb name in the registry link.