### PR TITLE
Update examples to reference correct orb name

### DIFF
--- a/src/examples/build-integration-command.yml
+++ b/src/examples/build-integration-command.yml
@@ -6,7 +6,7 @@ usage:
   version: 2.1
 
   orbs:
-    artifactory: circleci/artifactory@1.0.0
+    artifactory: jfrog/artifactory-orb@1.0.1
 
   jobs:
     build:

--- a/src/examples/publish-docker-custom-build.yml
+++ b/src/examples/publish-docker-custom-build.yml
@@ -11,7 +11,7 @@ usage:
   version: 2.1
 
   orbs:
-    artifactory: circleci/artifactory@1.0.0
+    artifactory: jfrog/artifactory-orb@1.0.1
 
   workflows:
     custom-docker-example:

--- a/src/examples/publish-docker-simple.yml
+++ b/src/examples/publish-docker-simple.yml
@@ -7,7 +7,7 @@ usage:
   version: 2.1
 
   orbs:
-    artifactory: circleci/artifactory@1.0.0
+    artifactory: jfrog/artifactory-orb@1.0.1
 
   workflows:
     simple-docker-example:

--- a/src/examples/upload-job.yml
+++ b/src/examples/upload-job.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    artifactory: circleci/artifactory@1.0.0
+    artifactory: jfrog/artifactory-orb@1.0.1
 
   workflows:
     publish:


### PR DESCRIPTION
This PR fixes #4 by using the correct orb name in the examples.