### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -2,3 +2,7 @@ version: 2.1
 
 description: |
   Install, configure, and use the JFrog Artifactory CLI
+
+display:
+  home_url: https://jfrog.com/artifactory/
+  source_url: https://github.com/jfrog/artifactory-orb


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.
