### PR TITLE
add docker-promote command/job

### DIFF
--- a/src/commands/docker-promote.yml
+++ b/src/commands/docker-promote.yml
@@ -43,7 +43,7 @@ parameters:
 
 steps:
   - run:
-      name: Docker push to JFrog registry
+      name: Promote Docker image in JFrog registry
       command: |
         jfrog rt dpr \
           <<parameters.source_image>> \

--- a/src/commands/docker-promote.yml
+++ b/src/commands/docker-promote.yml
@@ -1,0 +1,55 @@
+description: >
+  Promote an image from one JFrog Docker registry to another
+
+parameters:
+  source_image:
+    type: string
+    description: >
+      The Docker image name to promote
+
+  source-repository:
+    type: string
+    description: >
+      Source repository in Artifactory
+
+  source-tag:
+    type: string
+    default: ""
+    description: >
+      The tag name in the source repository to promote
+
+  target-image:
+    type: string
+    default: ""
+    description: >
+      Docker target image name
+
+  target-repository:
+    type: string
+    description: >
+      Target repository in Artifactory
+
+  target-tag:
+    type: string
+    default: ""
+    description: >
+      The target tag to assign the image after promotion
+
+  copy:
+    type: boolean
+    default: false
+    description: >
+      If set true, the Docker image is copied to the target repository, otherwise it is moved.
+
+steps:
+  - run:
+      name: Docker push to JFrog registry
+      command: |
+        jfrog rt dpr \
+          <<parameters.source_image>> \
+          <<parameters.source-repository>> \
+          <<parameters.target-repository>> \
+          <<#parameters.copy>>--copy<</parameters.copy>> \
+          <<#parameters.source-tag>>--source-tag="<<parameters.source-tag>>"<</parameters.source-tag>> \
+          <<#parameters.target-image>>--target-docker-image="<<parameters.target-image>>"<</parameters.target-image>> \
+          <<#parameters.target-tag>>--target-tag="<<parameters.target-tag>>"<</parameters.target-tag>>

--- a/src/examples/promote-docker-simple.yml
+++ b/src/examples/promote-docker-simple.yml
@@ -1,0 +1,23 @@
+description: >
+  Use the `docker-promote` job to promote a Docker image between JFrog repositories.
+
+usage:
+  version: 2.1
+
+  orbs:
+    artifactory: circleci/artifactory@1.0.0
+
+  workflows:
+    simple-docker-example:
+      jobs:
+        - artifactory/docker-publish:
+            name: Docker Publish Simple
+            docker-registry: orbdemos-docker-local.jfrog.io
+            repository: docker-local
+            docker-tag: orbdemos-docker-local.jfrog.io/hello-world:1.0-${CIRCLE_BUILD_NUM}
+        - artifactory/docker-promote:
+            name: Docker Promote Simple
+            source-repository: orbdemos-docker-local
+            source-image: hello-world
+            source-tag: 1.0-${CIRCLE_BUILD_NUM}
+            target-repository: orbdemos-docker-promoted

--- a/src/jobs/docker-promote.yml
+++ b/src/jobs/docker-promote.yml
@@ -1,0 +1,81 @@
+description: >
+  Configure the JFrog CLI and promote a Docker image.
+
+parameters:
+  artifactory-url:
+    type: env_var_name
+    default: ARTIFACTORY_URL
+    description: >
+      Name of environment variable storing the URL of your Artifactory
+      instance
+
+  artifactory-user:
+    type: env_var_name
+    default: ARTIFACTORY_USER
+    description: >
+      Name of environment variable storing your Artifactory username
+
+  artifactory-key:
+    type: env_var_name
+    default: ARTIFACTORY_API_KEY
+    description: >
+      Name of environment variable storing your Artifactory API key
+
+  source-image:
+    type: string
+    description: >
+      The Docker image name to promote
+
+  source-repository:
+    type: string
+    description: >
+      Source repository in Artifactory
+
+  source-tag:
+    type: string
+    default: ""
+    description: >
+      The tag name in the source repository to promote
+
+  target-image:
+    type: string
+    default: ""
+    description: >
+      Docker target image name
+
+  target-repository:
+    type: string
+    description: >
+      Target repository in Artifactory
+
+  target-tag:
+    type: string
+    default: ""
+    description: >
+      The target tag to assign the image after promotion
+
+  copy:
+    type: boolean
+    default: false
+    description: >
+      If set true, the Docker image is copied to the target repository, otherwise it is moved.
+
+executor: machine
+
+steps:
+  - checkout
+  - install
+
+  - configure:
+      artifactory-url: <<parameters.artifactory-url>>
+      artifactory-user: <<parameters.artifactory-user>>
+      artifactory-key: <<parameters.artifactory-key>>
+
+  - docker-promote:
+      source-image: <<parameters.source-image>>
+      source-repository: <<parameters.source-repository>>
+      source-tag: <<parameters.source-tag>>
+      target-image: <<parameters.target-image>>
+      target-repository: <<parameters.target-repository>>
+      target-tag: <<parameters.target-tag>>
+      copy: <<parameters.copy>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

We build a Docker image for each push to our repositories in CI. These images are used in dependent jobs to run tests. For pushes on the main branch that pass tests, we'll subsequently tag the image with a release identifier and then deploy it. Over time, this has lead to huge bloat (and cost) in our Docker repository. To mitigate this, we're planning to switch to 2 local Docker repositories, 1 for CI and 1 for releases, and using [image promotion](https://www.jfrog.com/confluence/display/JFROG/Docker+Registry#DockerRegistry-PromotingDockerImages) to copy images into the release repository. From there, we'll be able to safely use the "Max Unique Tags" setting to independently limit the number of CI and release builds we're storing.

https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory#CLIforJFrogArtifactory-PromotingDockerImages

### Description

* Add `docker-promote` command
* Add `docker-promote` job
