### PR TITLE
feat: allow custom version to be installed

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,15 +1,26 @@
 description: Install the JFrog CLI
 
+parameters:
+  version:
+    type: string
+    description: >
+      The version from the command-line tool to be installed.
+
 steps:
   - run:
       name: Install JFrog CLI
       command: |
+        VERSION=<<parameters.version>>
         echo "Checking for existence of CLI"
         set +e
         jfrog -v
         if [ $? -gt 0 ]; then
-          echo "Not found, installing latest"
-          curl -fL https://getcli.jfrog.io | sh
+          echo "Not found, installing ${VERSION:-latest}"
+          if [ -n "${VERSION}" ]; then
+            curl -fL https://getcli.jfrog.io | sh -s "${VERSION}"
+          else
+            curl -fL https://getcli.jfrog.io | sh
+          fi
           chmod a+x jfrog && sudo mv jfrog /usr/local/bin
         else
           echo "CLI exists, skipping install"

--- a/src/examples/install-custom-version.yml
+++ b/src/examples/install-custom-version.yml
@@ -1,0 +1,17 @@
+description: >
+  Install and configure the JFrog CLI, using a specific version.
+
+usage:
+  version: 2.1
+
+  orbs:
+    artifactory: circleci/artifactory@1.0.0
+
+  jobs:
+    build:
+      docker:
+        - image: cimg/base:2020.01
+      steps:
+        - checkout
+        - artifactory/install:
+            version: 1.45.0


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Using the `latest` version [works _almost all the time_](https://github.com/jfrog/jfrog-cli/issues/1004), but when a new release introduces a change that breaks your entire pipeline, we need to have a way to keep using a version that is working.

### Description

This change introduces a new parameter to the `install` command where you can specify a `version` to be installed, like:

```sh
      steps:
        - checkout
        - artifactory/install:
            version: 1.45.0
```

I tested using a custom script, without specifying a version:

```sh
circleci@24b22027b5ff:/src$ ./install.sh
+ VERSION=
+ echo 'Checking for existence of CLI'
Checking for existence of CLI
+ set +e
+ jfrog -v
./install.sh: line 7: jfrog: command not found
+ '[' 127 -gt 0 ']'
+ echo 'Not found, installing latest'
Not found, installing latest
+ '[' -n '' ']'
+ sh
+ curl -fL https://getcli.jfrog.io
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   178  100   178    0     0    262      0 --:--:-- --:--:-- --:--:--   262
100  1302  100  1302    0     0   1067      0  0:00:01  0:00:01 --:--:--  1067
Downloading the latest version of JFrog CLI...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
100 22.2M  100 22.2M    0     0  6759k      0  0:00:03  0:00:03 --:--:-- 13.4M
+ chmod a+x jfrog
+ sudo mv jfrog /usr/local/bin
```

Using a custom version:

```sh
circleci@56ee99fffd5b:/src$ ./install.sh
+ VERSION=1.45.0
+ echo 'Checking for existence of CLI'
Checking for existence of CLI
+ set +e
+ jfrog -v
./install.sh: line 7: jfrog: command not found
+ '[' 127 -gt 0 ']'
+ echo 'Not found, installing 1.45.0'
Not found, installing 1.45.0
+ '[' -n 1.45.0 ']'
+ sh -s 1.45.0
+ curl -fL https://getcli.jfrog.io
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   178  100   178    0     0    232      0 --:--:-- --:--:-- --:--:--   232
100  1302  100  1302    0     0    907      0  0:00:01  0:00:01 --:--:--   907
Downloading version 1.45.0 of JFrog CLI...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 22.2M  100 22.2M    0     0  7255k      0  0:00:03  0:00:03 --:--:-- 10.9M
+ chmod a+x jfrog
+ sudo mv jfrog /usr/local/bin
```