### PR TITLE
Fixing example scripts. They were having wrong orb information

### DIFF
--- a/src/examples/build-integration-command.yml
+++ b/src/examples/build-integration-command.yml
@@ -6,7 +6,7 @@ usage:
   version: 2.1
 
   orbs:
-    artifactory: circleci/artifactory@1.0.0
+    artifactory-orb: jfrog/artifactory-orb@1.0.1
 
   jobs:
     build:
@@ -14,6 +14,6 @@ usage:
         - image: circleci/node:10
       steps:
         - checkout
-        - artifactory/install
-        - artifactory/configure
-        - artifactory/build-integration
+        - artifactory-orb/install
+        - artifactory-orb/configure
+        - artifactory-orb/build-integration

--- a/src/examples/build-integration-command.yml
+++ b/src/examples/build-integration-command.yml
@@ -17,3 +17,4 @@ usage:
         - artifactory-orb/install
         - artifactory-orb/configure
         - artifactory-orb/build-integration
+

--- a/src/examples/install-custom-version.yml
+++ b/src/examples/install-custom-version.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    artifactory: circleci/artifactory@1.0.0
+    artifactory-orb: jfrog/artifactory-orb@1.0.1
 
   jobs:
     build:
@@ -13,5 +13,5 @@ usage:
         - image: cimg/base:2020.01
       steps:
         - checkout
-        - artifactory/install:
+        - artifactory-orb/install:
             version: 1.45.0

--- a/src/examples/promote-docker-simple.yml
+++ b/src/examples/promote-docker-simple.yml
@@ -5,17 +5,17 @@ usage:
   version: 2.1
 
   orbs:
-    artifactory: circleci/artifactory@1.0.0
+    artifactory-orb: jfrog/artifactory-orb@1.0.1
 
   workflows:
     simple-docker-example:
       jobs:
-        - artifactory/docker-publish:
+        - artifactory-orb/docker-publish:
             name: Docker Publish Simple
             docker-registry: orbdemos-docker-local.jfrog.io
             repository: docker-local
             docker-tag: orbdemos-docker-local.jfrog.io/hello-world:1.0-${CIRCLE_BUILD_NUM}
-        - artifactory/docker-promote:
+        - artifactory-orb/docker-promote:
             name: Docker Promote Simple
             source-repository: orbdemos-docker-local
             source-image: hello-world

--- a/src/examples/publish-docker-custom-build.yml
+++ b/src/examples/publish-docker-custom-build.yml
@@ -11,12 +11,12 @@ usage:
   version: 2.1
 
   orbs:
-    artifactory: circleci/artifactory@1.0.0
+    artifactory-orb: jfrog/artifactory-orb@1.0.1
 
   workflows:
     custom-docker-example:
       jobs:
-        - artifactory/docker-publish:
+        - artifactory-orb/docker-publish:
             name: Docker Publish Custom Build
             docker-registry: orbdemos-docker-local.jfrog.io
             repository: docker-local

--- a/src/examples/publish-docker-simple.yml
+++ b/src/examples/publish-docker-simple.yml
@@ -7,12 +7,12 @@ usage:
   version: 2.1
 
   orbs:
-    artifactory: circleci/artifactory@1.0.0
+    artifactory-orb: jfrog/artifactory-orb@1.0.1
 
   workflows:
     simple-docker-example:
       jobs:
-        - artifactory/docker-publish:
+        - artifactory-orb/docker-publish:
             name: Docker Publish Simple
             docker-registry: orbdemos-docker-local.jfrog.io
             repository: docker-local

--- a/src/examples/upload-job.yml
+++ b/src/examples/upload-job.yml
@@ -5,12 +5,12 @@ usage:
   version: 2.1
 
   orbs:
-    artifactory: circleci/artifactory@1.0.0
+    artifactory-orb: jfrog/artifactory-orb@1.0.1
 
   workflows:
     publish:
       jobs:
-        - artifactory/upload:
+        - artifactory-orb/upload:
             name: Publish Maven Jar
             source: test/artifact.jar
             target: repo/path


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

https://github.com/jfrog/artifactory-orb/issues/11

The orb documentation https://circleci.com/developer/orbs/orb/jfrog/artifactory-orb and examples were not matching. This may have been affecting orb adoption by more users. I faced issue while trying to implement this.

![image](https://user-images.githubusercontent.com/19341391/131891327-cc4b1692-b05f-43fd-881f-d1f4e8a30f41.png)


### Description

Changed orb information as per documentation https://circleci.com/developer/orbs/orb/jfrog/artifactory-orb to below
artifactory-orb: jfrog/artifactory-orb@1.0.1
Updated orb element name to artifactory-orb

I have read the CLA Document and I hereby sign the CLA