### PR TITLE
feat: Use password-stdin flag to follow best security practices

### DIFF
--- a/src/commands/docker-login.yml
+++ b/src/commands/docker-login.yml
@@ -24,4 +24,4 @@ steps:
   - run:
       name: Log into JFrog Docker registry
       command: |
-        docker login -u $<<parameters.artifactory-user>> -p $<<parameters.artifactory-key>> <<parameters.docker-registry>>
+        echo $<<parameters.artifactory-key>> | docker login -u $<<parameters.artifactory-user>> --password-stdin <<parameters.docker-registry>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This change supports best practices by not sending a password in plain text over the CLI.

### Description

Move -password usage to --password-stdin when running docker login