### PR TITLE
fix: use the latest base image instead

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   docker-image:
     type: string
-    default: "circleci/openjdk:8"
+    default: "cimg/base:2022.08"
     description: >
       Docker image to use in this executor, defaults to circleci/openjdk:8
 

--- a/src/jobs/upload.yml
+++ b/src/jobs/upload.yml
@@ -3,7 +3,7 @@ description: Upload artifacts to Artifactory
 parameters:
   docker:
     type: string
-    default: circleci/openjdk:8
+    default: cimg/base:2022.08
     description: Docker image to use for build
 
   build-steps:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

Switch to a supported image.

Fixes #16 

### Description

Preferring to pin it, rather than use the "stable" tag, so that
there's no surprising impact downstream.

We can manage the version manually, or use a tool such as
[renovate](https://github.com/marketplace/renovate), to automatically
bump the version for us (though I'm not really sure how cimg the images
are maintained today)